### PR TITLE
Remove `jupyterlab-eventlistener` dependency

### DIFF
--- a/packages/cell-input-footer-extension/README.md
+++ b/packages/cell-input-footer-extension/README.md
@@ -1,1 +1,1 @@
-# Event Listener Extension
+# jupyterlab-cell-input-footer extension

--- a/packages/cell-input-footer-extension/package.json
+++ b/packages/cell-input-footer-extension/package.json
@@ -58,8 +58,7 @@
     "dependencies": {
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/services": "^7.0.0",
-        "jupyterlab-cell-input-footer": "^0.3.1",
-        "jupyterlab-eventlistener": "^0.4.0-alpha.0"
+        "jupyterlab-cell-input-footer": "^0.3.1"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.5",

--- a/packages/cell-input-footer-extension/package.json
+++ b/packages/cell-input-footer-extension/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jupyterlab-cell-input-footer-extension",
     "version": "0.3.1",
-    "description": "JupyterLab Plugin providing a global event listener.",
+    "description": "JupyterLab extension to add a footer to cell inputs",
     "keywords": [
         "jupyter",
         "jupyterlab",

--- a/packages/cell-input-footer/README.md
+++ b/packages/cell-input-footer/README.md
@@ -1,1 +1,1 @@
-# Event Listener API
+# jupyterlab-cell-input-footer API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyterlab>=4,<5",
-    "jupyterlab_eventlistener>=0.4.0"
+    "jupyterlab>=4,<5"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9277,7 +9277,6 @@ __metadata:
     "@jupyterlab/services": ^7.0.0
     "@types/react": ~18.3.1
     jupyterlab-cell-input-footer: ^0.3.1
-    jupyterlab-eventlistener: ^0.4.0-alpha.0
     npm-run-all: ^4.1.5
     rimraf: ^4.1.2
     typescript: ~5.0.4
@@ -9297,16 +9296,6 @@ __metadata:
     typescript: ~5.0.4
   languageName: unknown
   linkType: soft
-
-"jupyterlab-eventlistener@npm:^0.4.0-alpha.0":
-  version: 0.4.0-alpha.0
-  resolution: "jupyterlab-eventlistener@npm:0.4.0-alpha.0"
-  dependencies:
-    "@jupyterlab/services": ^7.0.0
-    "@lumino/coreutils": ^2.1.2
-  checksum: 410f337795f03f18c1c74e2d2658b2fbfcf3cf82e70d09f7a829e4533e1a271f5bf3e453e915c27e1e74cc3e2eca596d777fe89ce540f9088d41cc9acb619f1d
-  languageName: node
-  linkType: hard
 
 "just-diff-apply@npm:^5.2.0":
   version: 5.5.0


### PR DESCRIPTION
This dependency appears to be unused in the code base.

Probably a leftover, since such dependency would not be needed to add footers to input cells.